### PR TITLE
Change the URL of heroku/heroku-buildpack-jvm-common

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -82,7 +82,7 @@ BP_DIR="$(cd "$(dirname "$0")" && pwd)"
 OPT_DIR=$BP_DIR/../opt/
 
 JDK_DIR="$BUILD_DIR/.jdk"
-JVM_COMMON_URL="https://raw.githubusercontent.com/heroku/heroku-buildpack-jvm-common/master/"
+JVM_COMMON_URL="https://raw.githubusercontent.com/heroku/heroku-buildpack-jvm-common/main/"
 
 install_corretto "$JDK_DIR"
 create_profile_scripts "$BUILD_DIR" "$JVM_COMMON_URL"


### PR DESCRIPTION
When using buildpack of corretto, the following error occurred and Java startup failed.

```
2020-07-29T04:36:33.063416+00:00 app[web.1]: /app/.profile.d/corretto.sh: line 1: 404:: command not found
2020-07-29T04:36:33.605474+00:00 app[web.1]: [heroku-exec] Starting
2020-07-29T04:36:33.606081+00:00 app[web.1]: /app/.profile.d/jdbc.sh: line 1: 404:: command not found
2020-07-29T04:36:33.606696+00:00 app[web.1]: bash: java: command not found
2020-07-29T04:36:33.651560+00:00 heroku[web.1]: Process exited with status 127
2020-07-29T04:36:33.696207+00:00 heroku[web.1]: State changed from starting to crashed
```

The reason is that the `master` branch name of `heroku/heroku-buildpack-jvm-common` has been changed to `main`.